### PR TITLE
Update README and Vite config to reference Custom Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # React + Vite
 
-Open [Routing](https://users.metropolia.fi/~jarkkaka/WSK-25/react/routing) to view it in the browser.
-
-Open [Hooks](https://users.metropolia.fi/~jarkkaka/WSK-25/react/hooks) to view it in the browser.
+Open [Custom-Hooks](https://users.metropolia.fi/~jarkkaka/WSK-25/react/custom-hooks) to view it in the browser.
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react-swc';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '~jarkkaka/WSK-25/react/hooks/',
+  base: '~jarkkaka/WSK-25/react/custom-hooks/',
 });


### PR DESCRIPTION
## Summary by Sourcery

Update project documentation and configuration to reference Custom Hooks instead of previous Hooks implementation

Deployment:
- Modify Vite configuration base path to point to the custom-hooks directory

Documentation:
- Update README.md to point to the Custom Hooks documentation link